### PR TITLE
Disable EL6 RPM features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN chmod +x /usr/bin/sbt && \
     mkdir -p /usr/share/sbt-launcher-packaging/bin && \
     ln -s /usr/bin/sbt-launch.jar /usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
 
+ADD rpmbuild /usr/local/bin/
+RUN chmod +x /usr/local/bin/rpmbuild
+
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 EXPOSE 22

--- a/rpmbuild
+++ b/rpmbuild
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/rpmbuild --define "_binary_filedigest_algorithm 1" --define "_binary_payload 1" "$@"


### PR DESCRIPTION
We do not have enough flexibility in overriding rpmbuild options in sbt, so we have to hardcode them in the script. These options are to avoid using modern rpmlib features not supported on rhel5.