### PR TITLE
Switchable java version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@ FROM centos:centos6
 MAINTAINER Alexey Wasilyev <awasilyev@qubell.com>
 
 ADD mongo.repo /etc/yum.repos.d/mongodb.repo
+ADD https://bintray.com/sbt/rpm/rpm /etc/yum.repos.d/bintray-sbt-rpm.repo
 
 RUN yum install -y epel-release centos-release-SCL && \
-    yum install -y java-1.7.0-openjdk openssh-server curl git tar sudo make patch gcc gcc-c++ python-setuptools bzip2 && \
-    yum install -y mongodb-org which java-1.7.0-openjdk-devel python27 rpm-build http-parser libuv wget nodejs npm Xvfb libxslt-devel libxml2-devel python-devel python-pip && \ 
-    yum install -y docker-io --enablerepo=epel-testing docker-io && \
+    yum install -y --enablerepo=epel-testing \
+                   java-1.7.0-openjdk-devel java-1.8.0-openjdk-devel sbt \
+                   openssh-server curl git tar sudo make patch gcc gcc-c++ python-setuptools bzip2 \
+                   mongodb-org which python27 rpm-build http-parser libuv wget nodejs npm Xvfb libxslt-devel libxml2-devel python-devel python-pip \ 
+                   docker-io && \
     yum localinstall -y 'https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.3/rabbitmq-server-3.5.3-1.noarch.rpm' && \
     yum localinstall -y 'https://packagecloud.io/chef/stable/download?distro=6&filename=chefdk-0.3.4-1.x86_64.rpm' && \
     yum localinstall -y 'http://downloads.onrooby.com/chromium/rpms/chromium-31.0.1650.63-1.el6.x86_64.rpm' && \
@@ -28,15 +31,11 @@ RUN mkdir -p /var/run/sshd && \
 
 RUN easy_install virtualenv supervisor argparse
 
-ADD sbt /usr/bin/
-ADD https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar /usr/bin/
-RUN chmod +x /usr/bin/sbt && \
-    chmod 755 /usr/bin/sbt-launch.jar && \
-    mkdir -p /usr/share/sbt-launcher-packaging/bin && \
-    ln -s /usr/bin/sbt-launch.jar /usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
-
 ADD rpmbuild /usr/local/bin/
 RUN chmod +x /usr/local/bin/rpmbuild
+
+ADD sbt /usr/local/bin/
+RUN chmod +x /usr/local/bin/sbt
 
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 

--- a/sbt
+++ b/sbt
@@ -1,16 +1,8 @@
-# Is the location of the SBT launcher JAR file.
-LAUNCHJAR="/usr/bin/sbt-launch.jar"
+#!/bin/bash
 
-# Customization: this may define JAVA_OPTS.
-SBTCONF=$HOME/.sbtconfig
-if [ -f "$SBTCONF" ]; then
-    . $SBTCONF
-fi
-if [ -z "$JAVA_OPTS" ]; then
-    # Ensure enough heap space is created for sbt.  These settings are
-    # the default settings from Typesafe's sbt wrapper.
-    JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xms1536m -Xmx4096m -XX:MaxPermSize=384m -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF8"
-fi
+JAVA_VERSION=$(sed -ne 's/java.version=\(.*\)/\1/p' project/build.properties 2>/dev/null || echo "1.7")
+JAVA_HOME=$(find /usr/lib/jvm -name "java-*-${JAVA_VERSION:-1.7}*" | sort | tail -n 1)
 
-# Assume java is already in the shell path.
-exec java $JAVA_OPTS -jar "$LAUNCHJAR" "$@"
+export JAVA_HOME
+
+/usr/bin/sbt -java-home "$JAVA_HOME" "$@"


### PR DESCRIPTION
If `project/build.properties` file exists and contains a line `java.version=XXX` then this version is used (`XXX` is a version prefix, for example `1.8`). Otherwise `1.7` is used.
Jenkins jobs are now required to use `sbt` binary instead of running `java -jar sbt-launch.jar` explicitly.
@awasilyev, please take a look